### PR TITLE
Added option to extend favorites hub

### DIFF
--- a/720p/Includes_Home.xml
+++ b/720p/Includes_Home.xml
@@ -1694,70 +1694,70 @@
 								<onclick>$INFO[Window.Property(favourite.11.Path)]</onclick>
 								<thumb>$INFO[Window.Property(favourite.11.Thumb)]</thumb>
 								<label>$INFO[Window.Property(favourite.11.Name)]</label>
-								<visible>!IsEmpty(Window.Property(favourite.11.Path)) + Skin.HasSetting(ExtendFavouritesSection)</visible>
+								<visible>!IsEmpty(Window.Property(favourite.11.Path))</visible>
 							</item>
 
 							<item id="12">
 								<onclick>$INFO[Window.Property(favourite.12.Path)]</onclick>
 								<thumb>$INFO[Window.Property(favourite.12.Thumb)]</thumb>
 								<label>$INFO[Window.Property(favourite.12.Name)]</label>
-								<visible>!IsEmpty(Window.Property(favourite.12.Path)) + Skin.HasSetting(ExtendFavouritesSection)</visible>
+								<visible>!IsEmpty(Window.Property(favourite.12.Path))</visible>
 							</item>
 							
 							<item id="13">
 								<onclick>$INFO[Window.Property(favourite.13.Path)]</onclick>
 								<thumb>$INFO[Window.Property(favourite.13.Thumb)]</thumb>
 								<label>$INFO[Window.Property(favourite.13.Name)]</label>
-								<visible>!IsEmpty(Window.Property(favourite.13.Path)) + Skin.HasSetting(ExtendFavouritesSection)</visible>
+								<visible>!IsEmpty(Window.Property(favourite.13.Path))</visible>
 							</item>
 							
 							<item id="14">
 								<onclick>$INFO[Window.Property(favourite.14.Path)]</onclick>
 								<thumb>$INFO[Window.Property(favourite.14.Thumb)]</thumb>
 								<label>$INFO[Window.Property(favourite.14.Name)]</label>
-								<visible>!IsEmpty(Window.Property(favourite.14.Path)) + Skin.HasSetting(ExtendFavouritesSection)</visible>
+								<visible>!IsEmpty(Window.Property(favourite.14.Path))</visible>
 							</item>
 							
 							<item id="15">
 								<onclick>$INFO[Window.Property(favourite.15.Path)]</onclick>
 								<thumb>$INFO[Window.Property(favourite.15.Thumb)]</thumb>
 								<label>$INFO[Window.Property(favourite.15.Name)]</label>
-								<visible>!IsEmpty(Window.Property(favourite.15.Path)) + Skin.HasSetting(ExtendFavouritesSection)</visible>
+								<visible>!IsEmpty(Window.Property(favourite.15.Path))</visible>
 							</item>
 
 							<item id="16">
 								<onclick>$INFO[Window.Property(favourite.16.Path)]</onclick>
 								<thumb>$INFO[Window.Property(favourite.16.Thumb)]</thumb>
 								<label>$INFO[Window.Property(favourite.16.Name)]</label>
-								<visible>!IsEmpty(Window.Property(favourite.16.Path)) + Skin.HasSetting(ExtendFavouritesSection)</visible>
+								<visible>!IsEmpty(Window.Property(favourite.16.Path))</visible>
 							</item>
 							
 							<item id="17">
 								<onclick>$INFO[Window.Property(favourite.17.Path)]</onclick>
 								<thumb>$INFO[Window.Property(favourite.17.Thumb)]</thumb>
 								<label>$INFO[Window.Property(favourite.17.Name)]</label>
-								<visible>!IsEmpty(Window.Property(favourite.17.Path)) + Skin.HasSetting(ExtendFavouritesSection)</visible>
+								<visible>!IsEmpty(Window.Property(favourite.17.Path))</visible>
 							</item>
 							
 							<item id="18">
 								<onclick>$INFO[Window.Property(favourite.18.Path)]</onclick>
 								<thumb>$INFO[Window.Property(favourite.18.Thumb)]</thumb>
 								<label>$INFO[Window.Property(favourite.18.Name)]</label>
-								<visible>!IsEmpty(Window.Property(favourite.18.Path)) + Skin.HasSetting(ExtendFavouritesSection)</visible>
+								<visible>!IsEmpty(Window.Property(favourite.18.Path))</visible>
 							</item>
 							
 							<item id="19">
 								<onclick>$INFO[Window.Property(favourite.19.Path)]</onclick>
 								<thumb>$INFO[Window.Property(favourite.19.Thumb)]</thumb>
 								<label>$INFO[Window.Property(favourite.19.Name)]</label>
-								<visible>!IsEmpty(Window.Property(favourite.19.Path)) + Skin.HasSetting(ExtendFavouritesSection)</visible>
+								<visible>!IsEmpty(Window.Property(favourite.19.Path))</visible>
 							</item>
 							
 							<item id="20">
 								<onclick>$INFO[Window.Property(favourite.20.Path)]</onclick>
 								<thumb>$INFO[Window.Property(favourite.20.Thumb)]</thumb>
 								<label>$INFO[Window.Property(favourite.20.Name)]</label>
-								<visible>!IsEmpty(Window.Property(favourite.20.Path)) + Skin.HasSetting(ExtendFavouritesSection)</visible>
+								<visible>!IsEmpty(Window.Property(favourite.20.Path))</visible>
 							</item>
 							
 						</content>

--- a/720p/SkinSettings.xml
+++ b/720p/SkinSettings.xml
@@ -401,17 +401,6 @@
 					
 				</control>
 				
-				<control type="radiobutton" id="122">
-					
-					<description>Extend favourites</description>
-					<include>Common_Settings_RadioButton</include>
-					<label>Extend favourites to 20 items (default 10)</label>
-					<onclick>Skin.ToggleSetting(ExtendFavouritesSection)</onclick>
-					<enable>Skin.HasSetting(ShowFavouritesSection)</enable>
-					<selected>Skin.HasSetting(ExtendFavouritesSection)</selected>
-					
-				</control>
-				
 			</control>
 			
 			<!--Hub Options-->


### PR DESCRIPTION
I needed more items in my favorites section (my room mates couldn't find all our on demand apps) so I added an option to show 20 items instead of the default 10.

Also, seems like degree signs got broken again. Maybe should switch to html entities or something that won't break?
