### PR TITLE
Bugfix: Fanart script wasn't grabbing random

### DIFF
--- a/720p/Home.xml
+++ b/720p/Home.xml
@@ -10,7 +10,7 @@
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(skinsettings)</onload>
 	<onload condition="!Skin.HasSetting(FirstTimeRun)">ActivateWindow(53)</onload>
 	
-	<onload condition="System.HasAddon(script.grab.fanart) + Skin.HasSetting(UseFanartBackground_Home)">XBMC.RunScript(script.grab.fanart,mode=Random,refresh=10)</onload>
+	<onload condition="System.HasAddon(script.grab.fanart) + Skin.HasSetting(UseFanartBackground_Home)">XBMC.RunScript(script.grab.fanart,mode=random,refresh=10)</onload>
 	
 	<controls>
 	


### PR DESCRIPTION
Seems like the script was case sensitive so instead of giving you
random fanart it gave you recent fanart. Fixed.
